### PR TITLE
README file reference incorrect in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from distutils.core import setup
 # retrieve the version number
 from coap import coapVersion
 VERSION     = '.'.join([str(v) for v in coapVersion.VERSION])
-with open('README.txt') as f:
+with open('README.md') as f:
     LONG_DESCRIPTION    = f.read()
 with open('COPYING.txt') as f:
     LICENSE             = f.read()


### PR DESCRIPTION
It looks like README.md was once README.txt setup.py still references this old file and prevents setup.py from running.
