### PR TITLE
COAP-32 add maxRetransmit number as a parameter that can be specified

### DIFF
--- a/coap/coap.py
+++ b/coap/coap.py
@@ -38,6 +38,7 @@ class coap(object):
         self.transmitters         = {}
         self.ackTimeout           = d.DFLT_ACK_TIMEOUT
         self.respTimeout          = d.DFLT_RESPONSE_TIMEOUT
+        self.maxRetransmit        = d.DFLT_MAX_RETRANSMIT
         if testing:
             self.socketUdp        = socketUdpDispatcher(
                 ipAddress         = self.ipAddress,
@@ -139,6 +140,7 @@ class coap(object):
                 payload      = payload,
                 ackTimeout   = self.ackTimeout,
                 respTimeout  = self.respTimeout,
+                maxRetransmit= self.maxRetransmit
             )
             key              = (destIp,destPort,token,messageId)
             assert key not in self.transmitters.keys()

--- a/coap/coapTransmitter.py
+++ b/coap/coapTransmitter.py
@@ -47,7 +47,7 @@ class coapTransmitter(threading.Thread):
         STATE_TXACK,
     ]
 
-    def __init__(self,sendFunc,srcIp,srcPort,destIp,destPort,confirmable,messageId,code,token,options,payload,ackTimeout,respTimeout):
+    def __init__(self,sendFunc,srcIp,srcPort,destIp,destPort,confirmable,messageId,code,token,options,payload,ackTimeout,respTimeout,maxRetransmit):
         '''
         \brief Initilizer function.
 
@@ -101,6 +101,7 @@ class coapTransmitter(threading.Thread):
         self.token           = token
         self.options         = options
         self.payload         = payload
+        self.maxRetransmit   = maxRetransmit
 
         # local variables
         self.dataLock        = threading.Lock()  # lock access to internal state
@@ -114,7 +115,6 @@ class coapTransmitter(threading.Thread):
         self.coapResponse    = None
         self.coapError       = None
         self.state           = self.STATE_INIT   # current state of the FSM
-        self.maxRetransmit   = d.DFLT_MAX_RETRANSMIT
         self.numTxCON        = 0
         self.ackTimeout      = ackTimeout
         self.respTimeout     = respTimeout


### PR DESCRIPTION
Hi @changtengfei I made a little change so that maxRetransmit can be also be tuned at need through CoAP client in code.
