### PR TITLE
CoAP-35. Add CBOR to the list of supported content formats.

### DIFF
--- a/coap/coapDefines.py
+++ b/coap/coapDefines.py
@@ -134,6 +134,7 @@ FORMAT_XML                             = 41
 FORMAT_OCTETSTREAM                     = 42
 FORMAT_EXI                             = 47
 FORMAT_JSON                            = 50
+FORMAT_CBOR                            = 60
 FORMAT_ALL = [
     FORMAT_TEXTPLAIN,
     FORMAT_LINKFORMAT,
@@ -141,4 +142,5 @@ FORMAT_ALL = [
     FORMAT_OCTETSTREAM,
     FORMAT_EXI,
     FORMAT_JSON,
+    FORMAT_CBOR,
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 PyDispatcher
-pylint
+pylint==1.6.0


### PR DESCRIPTION
This PR adds CBOR the the list of supported content formats according to RFC 7049 with assigned ID of 60.