### PR TITLE
COAP-38. Resolve host name to IP address in CoAP URI.

### DIFF
--- a/coap/coap.py
+++ b/coap/coap.py
@@ -9,6 +9,7 @@ log.addHandler(NullHandler())
 import threading
 import random
 import traceback
+import socket
 
 import coapTokenizer        as t
 import coapUtils            as u
@@ -130,7 +131,8 @@ class coap(object):
             assert payload==[]
         assert type(uri)==str
 
-        (destIp,destPort,uriOptions) = coapUri.uri2options(uri)
+        (host,destPort,uriOptions) = coapUri.uri2options(uri)
+        destIp = socket.getaddrinfo(host, destPort)[0][4][0]
         (securityContext, sequenceNumber) = oscoap.getRequestSecurityParams(oscoap.objectSecurityOptionLookUp(options))
 
         with self.transmittersLock:

--- a/coap/coapUri.py
+++ b/coap/coapUri.py
@@ -7,6 +7,7 @@ log.setLevel(logging.ERROR)
 log.addHandler(NullHandler())
 
 import re
+import socket
 
 import coapUtils     as u
 import coapOption    as o
@@ -109,7 +110,10 @@ def uri2options(uri):
     
     # remove hostPort
     uri       = uri.split(hostPort,1)[1]
-    
+
+    # convert host to IP address
+    host = socket.getaddrinfo(host, port)[0][4][0]
+
     # Uri-path
     paths     = [p for p in uri.split('?')[0].split('/') if p]
     log.debug('paths    : {0}'.format(paths))

--- a/coap/coapUri.py
+++ b/coap/coapUri.py
@@ -7,7 +7,6 @@ log.setLevel(logging.ERROR)
 log.addHandler(NullHandler())
 
 import re
-import socket
 
 import coapUtils     as u
 import coapOption    as o
@@ -110,9 +109,6 @@ def uri2options(uri):
     
     # remove hostPort
     uri       = uri.split(hostPort,1)[1]
-
-    # convert host to IP address
-    host = socket.getaddrinfo(host, port)[0][4][0]
 
     # Uri-path
     paths     = [p for p in uri.split('?')[0].split('/') if p]


### PR DESCRIPTION
This PR resolves host name to IP address as part of CoAP URI transformation. This is needed in order to create CoAP transmitter with a given IP address that is matched when a response arrives.