### PR TITLE
COAP-39. Make sure options are included in the error responses.

### DIFF
--- a/coap/coap.py
+++ b/coap/coap.py
@@ -239,11 +239,10 @@ class coap(object):
 
         srcPort = sender[1]
 
-        options = []
-
         # parse messages
         try:
             message = m.parseMessage(rawbytes)
+            options = message['options']
         except e.messageFormatError as err:
             log.warning('malformed message {0}: {1}'.format(u.formatBuf(rawbytes),str(err)))
             return
@@ -291,7 +290,7 @@ class coap(object):
                 else: # message not encrypted
                     payload = message['payload']
 
-                options = message['options'] + innerOptions
+                options += innerOptions
 
                 #==== find right resource
 


### PR DESCRIPTION
This PR fixes the issue of error codes not containing the Stateless-Proxy option, necessary for the Proxy to return the error response to the client.