### PR TITLE
Fix #COAP-42: Make hkdfDeriveParameter a public method

### DIFF
--- a/bin/test_client.py
+++ b/bin/test_client.py
@@ -9,6 +9,7 @@ import binascii
 from   coap import coap
 from coap import coapOption           as o
 from coap import coapObjectSecurity   as oscoap
+from coap import coapUtils            as u
 
 import logging_setup
 
@@ -26,13 +27,15 @@ objectSecurity = o.ObjectSecurity(context=context)
 
 try:
     # retrieve value of 'test' resource
-    p = c.GET('coap://[{0}]/test'.format(SERVER_IP),
+    (respCode, respOptions, respPayload) = c.GET('coap://[{0}]/test'.format(SERVER_IP),
               confirmable=True,
               options=[objectSecurity])
 
     print '====='
-    print ''.join([chr(b) for b in p])
+    print ''.join([chr(b) for b in respPayload])
+    print binascii.hexlify(u.buf2str(respPayload))
     print '====='
+
 except Exception as err:
     print err
 

--- a/coap/coap.py
+++ b/coap/coap.py
@@ -76,7 +76,7 @@ class coap(object):
             options     = options,
         )
         log.debug('response: {0}'.format(response))
-        return response['payload']
+        return (response['code'], response['options'], response['payload'])
 
     def PUT(self,uri,confirmable=True,options=[],payload=None):
         response = self._transmit(
@@ -87,7 +87,7 @@ class coap(object):
             payload     = payload
         )
         log.debug('response: {0}'.format(response))
-        return response['payload']
+        return (response['code'], response['options'], response['payload'])
 
     def POST(self,uri,confirmable=True,options=[],payload=None):
         response = self._transmit(
@@ -98,7 +98,7 @@ class coap(object):
             payload     = payload
         )
         log.debug('response: {0}'.format(response))
-        return response['payload']
+        return (response['code'], response['options'], response['payload'])
 
     def DELETE(self,uri,confirmable=True,options=[]):
         self._transmit(

--- a/tests/func/test_BADREQUEST.py
+++ b/tests/func/test_BADREQUEST.py
@@ -43,7 +43,7 @@ def test_BADREQUEST(logFixture, snoopyDispatcher, twoEndPoints, confirmableFixtu
         clientOptions = [o.ObjectSecurity(context=clientContext)]
 
         with pytest.raises(e.coapRcBadRequest):
-            reply = coap2.GET(
+            (respCode, respOptions, respPayload) = coap2.GET(
                 uri='coap://[{0}]:{1}/{2}/'.format(IPADDRESS1, d.DEFAULT_UDP_PORT, RESOURCE),
                 confirmable=confirmableFixture,
                 options=clientOptions

--- a/tests/func/test_INTERNALSERVERERROR.py
+++ b/tests/func/test_INTERNALSERVERERROR.py
@@ -71,7 +71,7 @@ def test_GET(logFixture,snoopyDispatcher,twoEndPoints):
     
     # have coap2 do a get
     with pytest.raises(e.coapRcInternalServerError):
-        reply = coap2.GET(
+        (respCode, respOptions, respPayload) = coap2.GET(
             uri         = 'coap://[{0}]:{1}/{2}/'.format(IPADDRESS1,d.DEFAULT_UDP_PORT,'buggy'),
             confirmable = True,
             options=clientOptions

--- a/tests/func/test_METHODNOTALLOWED.py
+++ b/tests/func/test_METHODNOTALLOWED.py
@@ -40,7 +40,7 @@ def test_METHODNOTALLOWED(logFixture,snoopyDispatcher,twoEndPoints,confirmableFi
     
     # have coap2 do a post
     with pytest.raises(e.coapRcMethodNotAllowed):
-        reply = coap2.POST(
+        (respCode, respOptions, respPayload) = coap2.POST(
             uri         = 'coap://[{0}]:{1}/{2}/'.format(IPADDRESS1,d.DEFAULT_UDP_PORT,RESOURCE),
             confirmable = confirmableFixture,
             options=options

--- a/tests/func/test_NOTFOUND.py
+++ b/tests/func/test_NOTFOUND.py
@@ -41,7 +41,7 @@ def test_NOTFOUND(logFixture,snoopyDispatcher,twoEndPoints,confirmableFixture):
     
     # have coap2 do a get
     with pytest.raises(e.coapRcNotFound):
-        reply = coap2.GET(
+        (respCode, respOptions, respPayload) = coap2.GET(
             uri         = 'coap://[{0}]:{1}/{2}/'.format(IPADDRESS1,d.DEFAULT_UDP_PORT,RESOURCE_INVALID),
             confirmable = confirmableFixture,
             options=options,

--- a/tests/func/test_UNAUTHORIZED.py
+++ b/tests/func/test_UNAUTHORIZED.py
@@ -36,7 +36,7 @@ def test_UNAUTHORIZED_1(logFixture,snoopyDispatcher,twoEndPoints,confirmableFixt
     if securityEnabled:
         # have coap2 do a get without including an Object-Security option
         with pytest.raises(e.coapRcUnauthorized):
-            reply = coap2.GET(
+            (respCode, respOptions, respPayload) = coap2.GET(
             uri         = 'coap://[{0}]:{1}/{2}/'.format(IPADDRESS1,d.DEFAULT_UDP_PORT,RESOURCE),
             confirmable = confirmableFixture,
             options=[]
@@ -61,7 +61,7 @@ def test_UNAUTHORIZED_2(logFixture, snoopyDispatcher, twoEndPoints, confirmableF
         clientOptions = [o.ObjectSecurity(context=clientContext)]
 
         with pytest.raises(e.coapRcUnauthorized):
-            reply = coap2.GET(
+            (respCode, respOptions, respPayload) = coap2.GET(
                 uri='coap://[{0}]:{1}/{2}/'.format(IPADDRESS1, d.DEFAULT_UDP_PORT, RESOURCE),
                 confirmable=confirmableFixture,
                 options=clientOptions

--- a/tests/func/test_multiple_CON.py
+++ b/tests/func/test_multiple_CON.py
@@ -36,10 +36,10 @@ def test_GET(logFixture,snoopyDispatcher,twoEndPoints):
     
     # have coap2 do a get
     for _ in range(20):
-        reply = coap2.GET(
+        (respCode, respOptions, respPayload) = coap2.GET(
             uri         = 'coap://[{0}]:{1}/{2}/'.format(IPADDRESS1,d.DEFAULT_UDP_PORT,RESOURCE),
             confirmable = False,
             options=options
         )
-        assert reply==DUMMYVAL
+        assert respPayload==DUMMYVAL
 

--- a/tests/func/test_multiple_NON.py
+++ b/tests/func/test_multiple_NON.py
@@ -35,9 +35,9 @@ def test_GET(logFixture,snoopyDispatcher,twoEndPoints):
     
     # have coap2 do a get
     for _ in range(20):
-        reply = coap2.GET(
+        (respCode, respOptions, respPayload) = coap2.GET(
             uri         = 'coap://[{0}]:{1}/{2}/'.format(IPADDRESS1,d.DEFAULT_UDP_PORT,RESOURCE),
             confirmable = False,
             options     = options
         )
-        assert reply==DUMMYVAL
+        assert respPayload==DUMMYVAL

--- a/tests/func/test_single_CON.py
+++ b/tests/func/test_single_CON.py
@@ -33,10 +33,10 @@ def test_GET(logFixture,snoopyDispatcher,twoEndPoints):
         options = [o.ObjectSecurity(context=context)]
 
     # have coap2 do a get
-    reply = coap2.GET(
+    (respCode, respOptions, respPayload) = coap2.GET(
         uri='coap://[{0}]:{1}/{2}/'.format(IPADDRESS1, d.DEFAULT_UDP_PORT, RESOURCE),
         confirmable=False,
         options=options
     )
-    assert reply == DUMMYVAL
+    assert respPayload == DUMMYVAL
     

--- a/tests/func/test_single_NON.py
+++ b/tests/func/test_single_NON.py
@@ -34,10 +34,10 @@ def test_GET(logFixture,snoopyDispatcher,twoEndPoints):
         options = [o.ObjectSecurity(context=context)]
     
     # have coap2 do a get
-    reply = coap2.GET(
+    (respCode, respOptions, respPayload) = coap2.GET(
         uri         = 'coap://[{0}]:{1}/{2}/'.format(IPADDRESS1,d.DEFAULT_UDP_PORT,RESOURCE),
         confirmable = False,
         options=options,
     )
-    assert reply==DUMMYVAL
+    assert respPayload==DUMMYVAL
     

--- a/tests/func/test_timeout_CON.py
+++ b/tests/func/test_timeout_CON.py
@@ -46,7 +46,7 @@ def test_GET(logFixture,snoopyDispatcher,twoEndPoints):
     
     # have coap2 do a get
     with pytest.raises(e.coapTimeout):
-        reply = coap2.GET(
+        (respCode, respOptions, respPayload) = coap2.GET(
             uri         = 'coap://[{0}]:{1}/{2}/'.format(IPADDRESS_INVALID,d.DEFAULT_UDP_PORT,RESOURCE),
             confirmable = True,
             options=options,

--- a/tests/func/test_timeout_NON.py
+++ b/tests/func/test_timeout_NON.py
@@ -46,7 +46,7 @@ def test_GET(logFixture,snoopyDispatcher,twoEndPoints):
     
     # have coap2 do a get
     with pytest.raises(e.coapTimeout):
-        reply = coap2.GET(
+        (respCode, respOptions, respPayload) = coap2.GET(
             uri         = 'coap://[{0}]:{1}/{2}/'.format(IPADDRESS_INVALID,d.DEFAULT_UDP_PORT,RESOURCE),
             confirmable = False,
             options=options


### PR DESCRIPTION
This allows an application code to use this method and derive other keys, that are not specific to OSCORE.