### PR TITLE
COAP-43: Implement No Response option with supress all responses value.

### DIFF
--- a/coap/coap.py
+++ b/coap/coap.py
@@ -376,7 +376,7 @@ class coap(object):
                         respOptions += [option]
                     # if No Response option was present in the request, don't send the response
                     if isinstance(option, o.NoResponse):
-                        if option.getPayloadBytes() == d.DFLT_OPTION_NORESPONSE_SUPRESS_ALL:
+                        if option.getPayloadBytes() == [d.DFLT_OPTION_NORESPONSE_SUPRESS_ALL]:
                             # exit without returning any response
                             log.info("Suppressing a response due to the {0} option in the request.".format(option))
                             return

--- a/coap/coap.py
+++ b/coap/coap.py
@@ -369,11 +369,20 @@ class coap(object):
                     objectSecurity = o.ObjectSecurity(context=foundContext)
                     respOptions += [objectSecurity]
 
-                # if Stateless-Proxy option was present in the request echo it
+                # process special options
                 for option in options:
+                    # if Stateless - Proxy option was present in the request echo it
                     if isinstance(option, o.StatelessProxy):
                         respOptions += [option]
-                        break
+                    # if No Response option was present in the request, don't send the response
+                    if isinstance(option, o.NoResponse):
+                        if option.getPayloadBytes() == d.DFLT_OPTION_NORESPONSE_SUPRESS_ALL:
+                            # exit without returning any response
+                            log.info("Suppressing a response due to the {0} option in the request.".format(option))
+                            return
+                        else:
+                            # selective suppression not implemented for now
+                            raise NotImplementedError()
 
                 # build response packets and pass partialIV from the request for OSCOAP's processing
                 response = m.buildMessage(

--- a/coap/coapDefines.py
+++ b/coap/coapDefines.py
@@ -17,6 +17,9 @@ DFLT_DEFAULT_LEISURE                   = 5    # in s. For multicast request, pic
 DFLT_EXCHANGE_LIFETIME                 = 248  # lifetime of a message ID
 DFLT_RESPONSE_TIMEOUT                  = 60   # delay for app-level response
 
+# Option value helpers
+DFLT_OPTION_NORESPONSE_SUPRESS_ALL     = 26   # RFC7967 value to supress all responses
+
 # CoAP Message Types
 TYPE_CON                               = 0
 TYPE_NON                               = 1
@@ -115,6 +118,7 @@ OPTION_NUM_PROXYURI                    = 35
 OPTION_NUM_PROXYSCHEME                 = 39
 OPTION_NUM_OBJECT_SECURITY             = 21 # plugtest value
 OPTION_NUM_STATELESSPROXY              = 40 # experimental value
+OPTION_NUM_NORESPONSE                  = 258 # RFC7967
 OPTION_NUM_ALL = [
     OPTION_NUM_IFMATCH,
     OPTION_NUM_URIHOST,
@@ -134,6 +138,7 @@ OPTION_NUM_ALL = [
     OPTION_NUM_PROXYSCHEME,
     OPTION_NUM_OBJECT_SECURITY,
     OPTION_NUM_STATELESSPROXY,
+    OPTION_NUM_NORESPONSE,
 ]
 
 # CoAP Content-Format Registry

--- a/coap/coapException.py
+++ b/coap/coapException.py
@@ -25,6 +25,11 @@ class coapException(Exception):
 class coapDelayedResponse(coapException):
     pass
 
+#============================ no response needed ==============================
+
+class coapNoResponseExpected(coapException):
+    pass
+
 #============================ timeout =========================================
 
 class coapTimeout(coapException):

--- a/coap/coapOption.py
+++ b/coap/coapOption.py
@@ -271,6 +271,25 @@ class StatelessProxy(coapOption):
 
     def getPayloadBytes(self):
         return self.opaqueValue
+
+# === OPTION_NUM_NORESPONSE
+class NoResponse(coapOption):
+    def __init__(self, buf):
+        # initialize parent
+        coapOption.__init__(self, d.OPTION_NUM_NORESPONSE, d.OSCOAP_CLASS_E)
+
+        # store params
+        if len(buf) != 1:
+            raise e.messageFormatError
+
+        self.supressionValue = u.buf2int(buf)
+
+    def __repr__(self):
+        return 'NoResponse(value={0})'.format(self.supressionValue)
+
+    def getPayloadBytes(self):
+        return self.supressionValue
+
 #============================ functions =======================================
 
 def parseOption(message,previousOptionNumber):
@@ -377,6 +396,8 @@ def parseOption(message,previousOptionNumber):
         option = ProxyScheme(scheme=''.join([chr(b) for b in optionValue]))
     elif optionNumber==d.OPTION_NUM_STATELESSPROXY:
         option = StatelessProxy(value=optionValue)
+    elif optionNumber==d.OPTION_NUM_NORESPONSE:
+        option = NoResponse(buf=optionValue)
     else:
         raise NotImplementedError('option {0} not implemented'.format(optionNumber))
     

--- a/coap/coapOption.py
+++ b/coap/coapOption.py
@@ -274,15 +274,15 @@ class StatelessProxy(coapOption):
 
 # === OPTION_NUM_NORESPONSE
 class NoResponse(coapOption):
-    def __init__(self, buf):
+    def __init__(self, value):
         # initialize parent
         coapOption.__init__(self, d.OPTION_NUM_NORESPONSE, d.OSCOAP_CLASS_E)
 
         # store params
-        if len(buf) != 1:
+        if len(value) != 1:
             raise e.messageFormatError
 
-        self.supressionValue = u.buf2int(buf)
+        self.supressionValue = value
 
     def __repr__(self):
         return 'NoResponse(value={0})'.format(self.supressionValue)
@@ -397,7 +397,7 @@ def parseOption(message,previousOptionNumber):
     elif optionNumber==d.OPTION_NUM_STATELESSPROXY:
         option = StatelessProxy(value=optionValue)
     elif optionNumber==d.OPTION_NUM_NORESPONSE:
-        option = NoResponse(buf=optionValue)
+        option = NoResponse(value=optionValue)
     else:
         raise NotImplementedError('option {0} not implemented'.format(optionNumber))
     

--- a/coap/coapOption.py
+++ b/coap/coapOption.py
@@ -274,7 +274,7 @@ class StatelessProxy(coapOption):
 
 # === OPTION_NUM_NORESPONSE
 class NoResponse(coapOption):
-    def __init__(self, value):
+    def __init__(self, value=[d.DFLT_OPTION_NORESPONSE_SUPRESS_ALL]):
         # initialize parent
         coapOption.__init__(self, d.OPTION_NUM_NORESPONSE, d.OSCOAP_CLASS_E)
 

--- a/tests/func/test_NORESPONSE.py
+++ b/tests/func/test_NORESPONSE.py
@@ -1,0 +1,48 @@
+import logging
+import testUtils as utils
+
+import time
+import threading
+
+import pytest
+
+from conftest import IPADDRESS1, \
+    RESOURCE, \
+    DUMMYVAL, \
+    OSCOAPMASTERSECRET, \
+    OSCOAPSERVERID, \
+    OSCOAPCLIENTID
+from coap import coapDefines as d, \
+    coapException as e, \
+    coapOption as o, \
+    coapObjectSecurity as oscoap
+
+# ============================ logging ===============================
+
+log = logging.getLogger(utils.getMyLoggerName())
+log.addHandler(utils.NullHandler())
+
+
+# ============================ tests ===========================================
+
+def test_GET(logFixture, snoopyDispatcher, twoEndPoints):
+    (coap1, coap2, securityEnabled) = twoEndPoints
+
+    options = []
+    if securityEnabled:
+        context = oscoap.SecurityContext(masterSecret=OSCOAPMASTERSECRET,
+                                         senderID=OSCOAPSERVERID,
+                                         recipientID=OSCOAPCLIENTID)
+
+        options = [o.ObjectSecurity(context=context)]
+
+    options += [o.NoResponse()]
+
+    # have coap2 do a get
+    with pytest.raises(e.coapNoResponseExpected):
+        reply = coap2.GET(
+            uri='coap://[{0}]:{1}/{2}/'.format(IPADDRESS1, d.DEFAULT_UDP_PORT, RESOURCE),
+            confirmable=False,
+            options=options,
+        )
+


### PR DESCRIPTION
This PR adds a minimal support for the No Response CoAP option, as specified by RFC7967.

No Response option enables the client to indicate that it is not interested in a particular class of responses. The PR implements the suppression of all responses only.

A new functional test is added in the test suite to demonstrate the use of the new functionality.