### PR TITLE
Update OSCORE to RFC8613.

### DIFF
--- a/bin/oscore_context_client.json
+++ b/bin/oscore_context_client.json
@@ -1,0 +1,13 @@
+{
+    "aeadAlgorithm": "AES_CCM_16_64_128",
+    "hashFunction": "sha256",
+    "idContext": "37cbf3210017a2d3",
+    "masterSalt": "9e7ca92223786340",
+    "masterSecret": "0102030405060708090a0b0c0d0e0f10",
+    "recipientID": "01",
+    "replayWindow": [
+        0
+    ],
+    "senderID": "",
+    "sequenceNumber": 0
+}

--- a/bin/oscore_context_server.json
+++ b/bin/oscore_context_server.json
@@ -1,0 +1,13 @@
+{
+    "aeadAlgorithm": "AES_CCM_16_64_128",
+    "hashFunction": "sha256",
+    "idContext": "37cbf3210017a2d3",
+    "masterSalt": "9e7ca92223786340",
+    "masterSecret": "0102030405060708090a0b0c0d0e0f10",
+    "recipientID": "",
+    "replayWindow": [
+        0
+    ],
+    "senderID": "01",
+    "sequenceNumber": 0
+}

--- a/bin/test_client.py
+++ b/bin/test_client.py
@@ -17,12 +17,7 @@ SERVER_IP = '::1'
 # open
 c = coap.coap(udpPort=5000)
 
-context = oscore.SecurityContext(masterSecret   = binascii.unhexlify('0102030405060708090a0b0c0d0e0f10'),
-                                 masterSalt     = binascii.unhexlify('9e7ca92223786340'),
-                                 senderID       = binascii.unhexlify(''),
-                                 recipientID    = binascii.unhexlify('01'),
-                                 idContext      = binascii.unhexlify('37cbf3210017a2d3'),
-                                 aeadAlgorithm  = oscore.AES_CCM_16_64_128())
+context = oscore.SecurityContext(securityContextFilePath="oscore_context_client.json")
 
 objectSecurity = o.ObjectSecurity(context=context)
 

--- a/bin/test_client.py
+++ b/bin/test_client.py
@@ -17,10 +17,12 @@ SERVER_IP = '::1'
 # open
 c = coap.coap(udpPort=5000)
 
-context = oscoap.SecurityContext(masterSecret=binascii.unhexlify('000102030405060708090A0B0C0D0E0F'),
-                                 senderID=binascii.unhexlify('636c69656e74'),
-                                 recipientID=binascii.unhexlify('736572766572'),
-                                 aeadAlgorithm=oscoap.AES_CCM_16_64_128())
+context = oscoap.SecurityContext(masterSecret   = binascii.unhexlify('0102030405060708090a0b0c0d0e0f10'),
+                                 masterSalt     = binascii.unhexlify('9e7ca92223786340'),
+                                 senderID       = binascii.unhexlify(''),
+                                 recipientID    = binascii.unhexlify('01'),
+                                 idContext      = binascii.unhexlify('37cbf3210017a2d3'),
+                                 aeadAlgorithm  = oscoap.AES_CCM_16_64_128())
 
 objectSecurity = o.ObjectSecurity(context=context)
 

--- a/bin/test_client.py
+++ b/bin/test_client.py
@@ -8,7 +8,7 @@ import binascii
 
 from   coap import coap
 from coap import coapOption           as o
-from coap import coapObjectSecurity   as oscoap
+from coap import coapObjectSecurity   as oscore
 
 import logging_setup
 
@@ -17,12 +17,12 @@ SERVER_IP = '::1'
 # open
 c = coap.coap(udpPort=5000)
 
-context = oscoap.SecurityContext(masterSecret   = binascii.unhexlify('0102030405060708090a0b0c0d0e0f10'),
+context = oscore.SecurityContext(masterSecret   = binascii.unhexlify('0102030405060708090a0b0c0d0e0f10'),
                                  masterSalt     = binascii.unhexlify('9e7ca92223786340'),
                                  senderID       = binascii.unhexlify(''),
                                  recipientID    = binascii.unhexlify('01'),
                                  idContext      = binascii.unhexlify('37cbf3210017a2d3'),
-                                 aeadAlgorithm  = oscoap.AES_CCM_16_64_128())
+                                 aeadAlgorithm  = oscore.AES_CCM_16_64_128())
 
 objectSecurity = o.ObjectSecurity(context=context)
 

--- a/bin/test_server.py
+++ b/bin/test_server.py
@@ -35,12 +35,7 @@ c = coap.coap(ipAddress='::1')
 
 testResource = testResource()
 
-context = oscore.SecurityContext(masterSecret   = binascii.unhexlify('0102030405060708090a0b0c0d0e0f10'),
-                                 masterSalt     = binascii.unhexlify('9e7ca92223786340'),
-                                 senderID       = binascii.unhexlify('01'),
-                                 recipientID    = binascii.unhexlify(''),
-                                 idContext      = binascii.unhexlify('37cbf3210017a2d3'),
-                                 aeadAlgorithm  = oscore.AES_CCM_16_64_128())
+context = oscore.SecurityContext(securityContextFilePath="oscore_context_server.json")
 
 # add resource - context binding with authorized methods
 testResource.addSecurityBinding((context, d.METHOD_ALL))

--- a/bin/test_server.py
+++ b/bin/test_server.py
@@ -8,7 +8,7 @@ import binascii
 from   coap   import    coap,                            \
                         coapResource,                    \
                         coapDefines         as d,        \
-                        coapObjectSecurity  as oscoap
+                        coapObjectSecurity  as oscore
 import logging_setup
 
 class testResource(coapResource.coapResource):
@@ -35,12 +35,12 @@ c = coap.coap(ipAddress='::1')
 
 testResource = testResource()
 
-context = oscoap.SecurityContext(masterSecret   = binascii.unhexlify('0102030405060708090a0b0c0d0e0f10'),
+context = oscore.SecurityContext(masterSecret   = binascii.unhexlify('0102030405060708090a0b0c0d0e0f10'),
                                  masterSalt     = binascii.unhexlify('9e7ca92223786340'),
                                  senderID       = binascii.unhexlify('01'),
                                  recipientID    = binascii.unhexlify(''),
                                  idContext      = binascii.unhexlify('37cbf3210017a2d3'),
-                                 aeadAlgorithm  = oscoap.AES_CCM_16_64_128())
+                                 aeadAlgorithm  = oscore.AES_CCM_16_64_128())
 
 # add resource - context binding with authorized methods
 testResource.addSecurityBinding((context, d.METHOD_ALL))

--- a/bin/test_server.py
+++ b/bin/test_server.py
@@ -35,9 +35,11 @@ c = coap.coap(ipAddress='::1')
 
 testResource = testResource()
 
-context = oscoap.SecurityContext(masterSecret   = binascii.unhexlify('000102030405060708090A0B0C0D0E0F'),
-                                 senderID       = binascii.unhexlify('736572766572'),
-                                 recipientID    = binascii.unhexlify('636c69656e74'),
+context = oscoap.SecurityContext(masterSecret   = binascii.unhexlify('0102030405060708090a0b0c0d0e0f10'),
+                                 masterSalt     = binascii.unhexlify('9e7ca92223786340'),
+                                 senderID       = binascii.unhexlify('01'),
+                                 recipientID    = binascii.unhexlify(''),
+                                 idContext      = binascii.unhexlify('37cbf3210017a2d3'),
                                  aeadAlgorithm  = oscoap.AES_CCM_16_64_128())
 
 # add resource - context binding with authorized methods

--- a/coap/coap.py
+++ b/coap/coap.py
@@ -165,13 +165,14 @@ class coap(object):
 
         if securityContext:
             try:
-                (innerOptions, plaintext) = oscoap.unprotectMessage(securityContext,
+                (decryptedCode, innerOptions, plaintext) = oscoap.unprotectMessage(securityContext,
                                                                     version=response['version'],
                                                                     code=response['code'],
                                                                     options=response['options'],
                                                                     ciphertext=response['ciphertext'],
                                                                     partialIV=sequenceNumber,
                                                                     )
+                response['code']    = decryptedCode
                 response['options'] = response['options'] + innerOptions
                 response['payload'] = plaintext
             except e.oscoapError:
@@ -276,13 +277,15 @@ class coap(object):
 
                     # decrypt the message
                     try:
-                        (innerOptions, plaintext) = oscoap.unprotectMessage(foundContext,
+                        (decryptedCode, innerOptions, plaintext) = oscoap.unprotectMessage(foundContext,
                                                                           version=message['version'],
                                                                           code=message['code'],
                                                                           options=message['options'],
                                                                           ciphertext=message['ciphertext'],
                                                                           partialIV=requestPartialIV
                                                                             )
+                        message['code'] = decryptedCode
+
                     except e.oscoapError as err:
                         raise e.coapRcBadRequest('OSCOAP unprotect failed: {0}'.format(str(err)))
 

--- a/coap/coap.py
+++ b/coap/coap.py
@@ -265,7 +265,7 @@ class coap(object):
 
                     if not blindContext:
                         if self.secContextHandler:
-                            appContext = self.secContextHandler(u.buf2str(message['kid']))
+                            appContext = self.secContextHandler(u.buf2str(message['kid']), u.buf2str(message['kidContext']))
                             if not appContext:
                                 raise e.coapRcUnauthorized('Security context not found.')
                         else:

--- a/coap/coapDefines.py
+++ b/coap/coapDefines.py
@@ -3,10 +3,10 @@ COAP_VERSION                           = 1
 COAP_PAYLOAD_MARKER                    = 0xff
 COAP_SCHEME                            = 'coap://'
 
-# OSCOAP option classes
-OSCOAP_CLASS_E                         = 'E'  # encrypted and integrity protected
-OSCOAP_CLASS_I                         = 'I'  # integrity protected
-OSCOAP_CLASS_U                         = 'U'  # unprotected
+# OSCORE option classes
+OSCORE_CLASS_E                         = 'E'  # encrypted and integrity protected
+OSCORE_CLASS_I                         = 'I'  # integrity protected
+OSCORE_CLASS_U                         = 'U'  # unprotected
 
 # Default transmission parameters
 DFLT_ACK_TIMEOUT                       = 20   # in s. 
@@ -154,7 +154,7 @@ FORMAT_ALL = [
     FORMAT_CBOR,
 ]
 
-# COSE defines for AES-CCM algorithm used in OSCoAP (c.f. draft-ietf-cose-msg-24)
+# COSE defines for AES-CCM algorithm used in OSCORE (c.f. draft-ietf-cose-msg-24)
 COSE_AES_CCM_16_64_128                 = 10
 COSE_AES_CCM_16_64_256                 = 11
 COSE_AES_CCM_64_64_128                 = 12

--- a/coap/coapDefines.py
+++ b/coap/coapDefines.py
@@ -103,6 +103,7 @@ OPTION_NUM_ETAG                        = 4
 OPTION_NUM_IFNONEMATCH                 = 5
 OPTION_NUM_URIPORT                     = 7
 OPTION_NUM_LOCATIONPATH                = 8
+OPTION_NUM_OSCORE                      = 9 # rfc8613
 OPTION_NUM_URIPATH                     = 11
 OPTION_NUM_CONTENTFORMAT               = 12
 OPTION_NUM_MAXAGE                      = 14
@@ -113,7 +114,6 @@ OPTION_NUM_BLOCK2                      = 23
 OPTION_NUM_BLOCK1                      = 27
 OPTION_NUM_PROXYURI                    = 35
 OPTION_NUM_PROXYSCHEME                 = 39
-OPTION_NUM_OBJECT_SECURITY             = 21 # plugtest value
 OPTION_NUM_STATELESSPROXY              = 40 # experimental value
 OPTION_NUM_ALL = [
     OPTION_NUM_IFMATCH,
@@ -132,7 +132,7 @@ OPTION_NUM_ALL = [
     OPTION_NUM_BLOCK1,
     OPTION_NUM_PROXYURI,
     OPTION_NUM_PROXYSCHEME,
-    OPTION_NUM_OBJECT_SECURITY,
+    OPTION_NUM_OSCORE,
     OPTION_NUM_STATELESSPROXY,
 ]
 

--- a/coap/coapException.py
+++ b/coap/coapException.py
@@ -38,9 +38,9 @@ class coapMalformattedUri(coapException):
 class messageFormatError(coapException):
     pass
 
-#======================== oscoap verification =================================
+#======================== oscore verification =================================
 
-class oscoapError(coapException):
+class oscoreError(coapException):
     pass
 
 #============================ return codes ====================================

--- a/coap/coapMessage.py
+++ b/coap/coapMessage.py
@@ -10,7 +10,7 @@ import coapOption         as o
 import coapUtils          as u
 import coapException      as e
 import coapDefines        as d
-import coapObjectSecurity as oscoap
+import coapObjectSecurity as oscore
 
 def sortOptions(options):
     # TODO implement sorting when more options are implemented
@@ -47,13 +47,13 @@ def buildMessage(msgtype,token,code,messageId,options=[],payload=[],securityCont
             raise ValueError('token {0} too long'.format(token))
 
     if securityContext:
-        # invoke oscoap to protect the message
-        (protectedCode, outerOptions, newPayload) = oscoap.protectMessage(context=securityContext,
-                                                           version = d.COAP_VERSION,
-                                                           code = code,
-                                                           options = options,
-                                                           payload = payload,
-                                                           partialIV=partialIV)
+        # invoke oscore to protect the message
+        (protectedCode, outerOptions, newPayload) = oscore.protectMessage(context=securityContext,
+                                                                          version = d.COAP_VERSION,
+                                                                          code = code,
+                                                                          options = options,
+                                                                          payload = payload,
+                                                                          partialIV=partialIV)
     else:
         (protectedCode, outerOptions, newPayload) = (code, options, payload)
 
@@ -107,11 +107,11 @@ def parseMessage(message):
     (returnVal['options'], payload) = decodeOptionsAndPayload(message)
 
     # if object security option is present decode the value in order to be able to decrypt the message
-    objectSecurity = oscoap.objectSecurityOptionLookUp(returnVal['options'])
+    objectSecurity = oscore.objectSecurityOptionLookUp(returnVal['options'])
     if objectSecurity:
-        oscoapDict = oscoap.parseObjectSecurity(objectSecurity.getPayloadBytes(), payload)
-        objectSecurity.setKid(oscoapDict['kid'])
-        returnVal.update(oscoapDict)
+        oscoreDict = oscore.parseObjectSecurity(objectSecurity.getPayloadBytes(), payload)
+        objectSecurity.setKid(oscoreDict['kid'])
+        returnVal.update(oscoreDict)
     else:
         returnVal['payload'] = payload
 

--- a/coap/coapMessage.py
+++ b/coap/coapMessage.py
@@ -45,26 +45,26 @@ def buildMessage(msgtype,token,code,messageId,options=[],payload=[],securityCont
                 break
         if not TKL:
             raise ValueError('token {0} too long'.format(token))
-    
-    # header
-    message += [d.COAP_VERSION<<6 | msgtype<<4 | TKL]
-    message += [code]
-    message += u.int2buf(messageId,2)
-    message += u.int2buf(token,TKL)
-    
-    # options
-    options  = sortOptions(options)
 
     if securityContext:
         # invoke oscoap to protect the message
-        (outerOptions, newPayload) = oscoap.protectMessage(context=securityContext,
+        (protectedCode, outerOptions, newPayload) = oscoap.protectMessage(context=securityContext,
                                                            version = d.COAP_VERSION,
                                                            code = code,
                                                            options = options,
                                                            payload = payload,
                                                            partialIV=partialIV)
     else:
-        (outerOptions, newPayload) = (options, payload)
+        (protectedCode, outerOptions, newPayload) = (code, options, payload)
+
+    # header
+    message += [d.COAP_VERSION<<6 | msgtype<<4 | TKL]
+    message += [protectedCode]
+    message += u.int2buf(messageId,2)
+    message += u.int2buf(token,TKL)
+
+    # options
+    options  = sortOptions(options)
 
     # add encoded options
     message += encodeOptions(outerOptions)

--- a/coap/coapMessage.py
+++ b/coap/coapMessage.py
@@ -37,7 +37,7 @@ def buildMessage(msgtype,token,code,messageId,options=[],payload=[],securityCont
     message   = []
 
     TKL = 0
-    if token:
+    if token is not None:
         # determine token length
         for tokenLen in range(1,8+1):
             if token < (1<<(8*tokenLen)):

--- a/coap/coapMessage.py
+++ b/coap/coapMessage.py
@@ -111,6 +111,7 @@ def parseMessage(message):
     if objectSecurity:
         oscoreDict = oscore.parseObjectSecurity(objectSecurity.getPayloadBytes(), payload)
         objectSecurity.setKid(oscoreDict['kid'])
+        objectSecurity.setKidContext(oscoreDict['kidContext'])
         returnVal.update(oscoreDict)
     else:
         returnVal['payload'] = payload

--- a/coap/coapObjectSecurity.py
+++ b/coap/coapObjectSecurity.py
@@ -389,7 +389,7 @@ class AES_CCM_16_64_128(CCMAlgorithm):
 class SecurityContext:
     REPLAY_WINDOW_SIZE = 64
 
-    def __init__(self, masterSecret, senderID, recipientID, idContext=None, aeadAlgorithm=AES_CCM_64_64_128(), masterSalt='',
+    def __init__(self, masterSecret, senderID, recipientID, idContext=None, aeadAlgorithm=AES_CCM_16_64_128(), masterSalt='',
                  hashFunction=hashlib.sha256):
 
         if len(senderID) > aeadAlgorithm.maxIdLen or len(recipientID) > aeadAlgorithm.maxIdLen:

--- a/coap/coapObjectSecurity.py
+++ b/coap/coapObjectSecurity.py
@@ -233,6 +233,8 @@ def _encodeCompressedCOSE(partialIV, kid, kidContext):
     if kidFlag:
         buffer += u.str2buf(kid)
 
+    if buffer == [0]:
+        return []
     return buffer
 
 '''

--- a/coap/coapObjectSecurity.py
+++ b/coap/coapObjectSecurity.py
@@ -175,7 +175,7 @@ def parseObjectSecurity(optionValue, payload):
         returnVal['partialIV'] = optionValue[:n]
         optionValue = optionValue[n:]
 
-    returnVal['kidContext'] = []
+    returnVal['kidContext'] = None
     if h:
         kidContextLen = optionValue[0]
         optionValue = optionValue[1:]

--- a/coap/coapObjectSecurity.py
+++ b/coap/coapObjectSecurity.py
@@ -175,6 +175,7 @@ def parseObjectSecurity(optionValue, payload):
         returnVal['partialIV'] = optionValue[:n]
         optionValue = optionValue[n:]
 
+    returnVal['kidContext'] = []
     if h:
         kidContextLen = optionValue[0]
         optionValue = optionValue[1:]

--- a/coap/coapObjectSecurity.py
+++ b/coap/coapObjectSecurity.py
@@ -133,15 +133,15 @@ def unprotectMessage(context, version, code, options=[], ciphertext=[], partialI
             ciphertext=u.buf2str(ciphertext),
             key=context.recipientKey,
             nonce=nonce)
+
+        plaintextBuf = u.str2buf(plaintext)
+        decryptedCode = plaintextBuf[0]
+        plaintextBuf = plaintext[1:]
     except e.oscoreError:
         raise
 
     if _isRequest(code):
         context.replayWindowUpdate(u.buf2int(u.str2buf(partialIV)))
-
-    plaintextBuf = u.str2buf(plaintext)
-    decryptedCode = plaintextBuf[0]
-    plaintextBuf = plaintext[1:]
 
     (innerOptions, payload) = m.decodeOptionsAndPayload(u.str2buf(plaintextBuf))
     # returns a tuple (decryptedCode, innerOptions, payload)

--- a/coap/coapOption.py
+++ b/coap/coapOption.py
@@ -235,14 +235,14 @@ class ObjectSecurity(coapOption):
     def __init__(self, context=None, payload=[], kid=None):
 
         # initialize parent
-        coapOption.__init__(self, d.OPTION_NUM_OBJECT_SECURITY, d.OSCOAP_CLASS_U)
+        coapOption.__init__(self, d.OPTION_NUM_OSCORE, d.OSCOAP_CLASS_U)
 
         self.context = context
         self.value = payload
         self.kid = kid
 
     def __repr__(self):
-        return 'ObjectSecurity(context={0},payload={1}, kid={2})'.format(self.context, self.value, self.kid)
+        return 'OSCORE(context={0},payload={1}, kid={2})'.format(self.context, self.value, self.kid)
 
     def setValue(self, payload):
         self.value = payload
@@ -371,7 +371,7 @@ def parseOption(message,previousOptionNumber):
         option = ContentFormat(cformat=optionValue)
     elif optionNumber==d.OPTION_NUM_BLOCK2:
         option = Block2(rawbytes=optionValue)
-    elif optionNumber==d.OPTION_NUM_OBJECT_SECURITY:
+    elif optionNumber==d.OPTION_NUM_OSCORE:
         option = ObjectSecurity(payload=optionValue)
     elif optionNumber==d.OPTION_NUM_PROXYSCHEME:
         option = ProxyScheme(scheme=''.join([chr(b) for b in optionValue]))

--- a/coap/coapOption.py
+++ b/coap/coapOption.py
@@ -232,7 +232,7 @@ class ProxyScheme(coapOption):
 
 class ObjectSecurity(coapOption):
 
-    def __init__(self, context=None, payload=[], kid=None):
+    def __init__(self, context=None, payload=[], kid=None, kidContext=None):
 
         # initialize parent
         coapOption.__init__(self, d.OPTION_NUM_OSCORE, d.OSCORE_CLASS_U)
@@ -240,15 +240,19 @@ class ObjectSecurity(coapOption):
         self.context = context
         self.value = payload
         self.kid = kid
+        self.kidContext = kidContext
 
     def __repr__(self):
-        return 'OSCORE(context={0},payload={1}, kid={2})'.format(self.context, self.value, self.kid)
+        return 'OSCORE(context={0},payload={1}, kid={2}, kidContext={3})'.format(self.context, self.value, self.kid, self.kidContext)
 
     def setValue(self, payload):
         self.value = payload
 
     def setKid(self,kid):
         self.kid = kid
+
+    def setKidContext(self,kidContext):
+        self.kidContext = kidContext
 
     def setContext(self,context):
         self.context = context

--- a/coap/coapOption.py
+++ b/coap/coapOption.py
@@ -14,11 +14,11 @@ import coapDefines   as d
 
 class coapOption(object):
     
-    def __init__(self,optionNumber, oscoapClass=d.OSCOAP_CLASS_E):
+    def __init__(self, optionNumber, oscoreClass=d.OSCORE_CLASS_E):
         
         # store params
         self.optionNumber = optionNumber
-        self.oscoapClass  = oscoapClass
+        self.oscoreClass  = oscoreClass
         self.length       = 0
     
     #======================== abstract methods ================================
@@ -74,7 +74,7 @@ class coapOption(object):
 class UriHost(coapOption):
     def __init__(self, host):
         # initialize parent
-        coapOption.__init__(self, d.OPTION_NUM_URIHOST, d.OSCOAP_CLASS_U)
+        coapOption.__init__(self, d.OPTION_NUM_URIHOST, d.OSCORE_CLASS_U)
 
         # store params
         self.host = host
@@ -100,7 +100,7 @@ class UriPath(coapOption):
     def __init__(self,path):
         
         # initialize parent
-        coapOption.__init__(self,d.OPTION_NUM_URIPATH, d.OSCOAP_CLASS_E)
+        coapOption.__init__(self, d.OPTION_NUM_URIPATH, d.OSCORE_CLASS_E)
         
         # store params
         self.path = path
@@ -124,7 +124,7 @@ class ContentFormat(coapOption):
         assert cformat[0] in d.FORMAT_ALL
         
         # initialize parent
-        coapOption.__init__(self,d.OPTION_NUM_CONTENTFORMAT, d.OSCOAP_CLASS_E)
+        coapOption.__init__(self, d.OPTION_NUM_CONTENTFORMAT, d.OSCORE_CLASS_E)
         
         # store params
         self.format = cformat[0]
@@ -147,7 +147,7 @@ class Accept(coapOption):
         assert accept[0] in d.FORMAT_ALL
 
         # initialize parent
-        coapOption.__init__(self, d.OPTION_NUM_ACCEPT, d.OSCOAP_CLASS_E)
+        coapOption.__init__(self, d.OPTION_NUM_ACCEPT, d.OSCORE_CLASS_E)
 
         # store params
         self.accept = accept[0]
@@ -177,7 +177,7 @@ class Block2(coapOption):
             assert szx!=None
         
         # initialize parent
-        coapOption.__init__(self,d.OPTION_NUM_BLOCK2, d.OSCOAP_CLASS_E)
+        coapOption.__init__(self, d.OPTION_NUM_BLOCK2, d.OSCORE_CLASS_E)
         
         # store params
         if num:
@@ -217,7 +217,7 @@ class Block2(coapOption):
 class ProxyScheme(coapOption):
     def __init__(self, scheme):
         # initialize parent
-        coapOption.__init__(self, d.OPTION_NUM_PROXYSCHEME, d.OSCOAP_CLASS_U)
+        coapOption.__init__(self, d.OPTION_NUM_PROXYSCHEME, d.OSCORE_CLASS_U)
 
         # store params
         self.scheme = scheme
@@ -235,7 +235,7 @@ class ObjectSecurity(coapOption):
     def __init__(self, context=None, payload=[], kid=None):
 
         # initialize parent
-        coapOption.__init__(self, d.OPTION_NUM_OSCORE, d.OSCOAP_CLASS_U)
+        coapOption.__init__(self, d.OPTION_NUM_OSCORE, d.OSCORE_CLASS_U)
 
         self.context = context
         self.value = payload
@@ -261,7 +261,7 @@ class ObjectSecurity(coapOption):
 class StatelessProxy(coapOption):
     def __init__(self, value):
         # initialize parent
-        coapOption.__init__(self, d.OPTION_NUM_STATELESSPROXY, d.OSCOAP_CLASS_U)
+        coapOption.__init__(self, d.OPTION_NUM_STATELESSPROXY, d.OSCORE_CLASS_U)
 
         # store params
         self.opaqueValue = value

--- a/coap/coapResource.py
+++ b/coap/coapResource.py
@@ -8,7 +8,6 @@ log.addHandler(NullHandler())
 
 import coapException        as e
 import coapDefines          as d
-import coapObjectSecurity   as oscoap
 
 class coapResource(object):
     
@@ -64,4 +63,3 @@ class coapResource(object):
         else:
             # if no context is bound to the resource, all methods are authorized
             return (None, d.METHOD_ALL)
-

--- a/coap/coapTransmitter.py
+++ b/coap/coapTransmitter.py
@@ -83,7 +83,7 @@ class coapTransmitter(threading.Thread):
             This function does not parse this payload, which is written as-is
             in the CoAP request.
         \param[in] securityContext Security context used for protection of the request
-        \param[in] requestSeq OSCOAP's sequence number from the request.
+        \param[in] requestSeq OSCORE's sequence number from the request.
         \param[in] ackTimeout The ACK timeout.
         \param[in] respTimeout The app-level response timeout.
         '''

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -48,8 +48,8 @@ RESOURCE            = 'res'
 DUMMYVAL            = [0x00,0x01,0x02]
 
 OSCOAPMASTERSECRET  = binascii.unhexlify('000102030405060708090A0B0C0D0E0F')
-OSCOAPSERVERID      = binascii.unhexlify('00212ffffeb56e1001')
-OSCOAPCLIENTID      = binascii.unhexlify('00212ffffeb56e1000')
+OSCOAPSERVERID      = binascii.unhexlify('01')
+OSCOAPCLIENTID      = binascii.unhexlify('')
 
 #============================ fixtures ========================================
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -47,9 +47,10 @@ IPADDRESS2          = 'aaaa::2'
 RESOURCE            = 'res'
 DUMMYVAL            = [0x00,0x01,0x02]
 
-OSCOREMASTERSECRET  = binascii.unhexlify('000102030405060708090A0B0C0D0E0F')
-OSCORESERVERID      = binascii.unhexlify('01')
-OSCORECLIENTID      = binascii.unhexlify('')
+OSCORECLIENTCONTEXT             = os.path.join(here, "oscore_test_context_client.json")
+OSCORESERVERCONTEXT             = os.path.join(here, "oscore_test_context_server.json")
+OSCOREDUMMYMASTERSECRETCONTEXT  = os.path.join(here, "oscore_test_context_dummymastersecret.json")
+OSCOREDUMMYSENDERIDCONTEXT      = os.path.join(here, "oscore_test_context_dummysenderid.json")
 
 #============================ fixtures ========================================
 
@@ -177,9 +178,7 @@ def twoEndPoints(request):
     newResource = dummyResource()
 
     if request.param == True: # if testing with security, protect the resource with security context
-        context = oscore.SecurityContext(masterSecret=OSCOREMASTERSECRET,
-                                         senderID=OSCORECLIENTID,
-                                         recipientID=OSCORESERVERID)
+        context = oscore.SecurityContext(OSCORESERVERCONTEXT)
 
         # add resource - context binding with authorized methods
         newResource.addSecurityBinding((context, d.METHOD_ALL))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,7 +17,7 @@ import snoopyDispatcher as snoopyDis
 from coap import coap, \
                  coapDefines        as d,       \
                  coapResource,                  \
-                 coapObjectSecurity as oscoap
+                 coapObjectSecurity as oscore
 
 #============================ logging =========================================
 
@@ -47,9 +47,9 @@ IPADDRESS2          = 'aaaa::2'
 RESOURCE            = 'res'
 DUMMYVAL            = [0x00,0x01,0x02]
 
-OSCOAPMASTERSECRET  = binascii.unhexlify('000102030405060708090A0B0C0D0E0F')
-OSCOAPSERVERID      = binascii.unhexlify('01')
-OSCOAPCLIENTID      = binascii.unhexlify('')
+OSCOREMASTERSECRET  = binascii.unhexlify('000102030405060708090A0B0C0D0E0F')
+OSCORESERVERID      = binascii.unhexlify('01')
+OSCORECLIENTID      = binascii.unhexlify('')
 
 #============================ fixtures ========================================
 
@@ -177,9 +177,9 @@ def twoEndPoints(request):
     newResource = dummyResource()
 
     if request.param == True: # if testing with security, protect the resource with security context
-        context = oscoap.SecurityContext(masterSecret=OSCOAPMASTERSECRET,
-                                         senderID=OSCOAPCLIENTID,
-                                         recipientID=OSCOAPSERVERID)
+        context = oscore.SecurityContext(masterSecret=OSCOREMASTERSECRET,
+                                         senderID=OSCORECLIENTID,
+                                         recipientID=OSCORESERVERID)
 
         # add resource - context binding with authorized methods
         newResource.addSecurityBinding((context, d.METHOD_ALL))

--- a/tests/func/test_BADREQUEST.py
+++ b/tests/func/test_BADREQUEST.py
@@ -4,6 +4,8 @@ import testUtils as utils
 import time
 import threading
 
+import os
+
 import pytest
 
 import binascii
@@ -11,9 +13,7 @@ import binascii
 from conftest import IPADDRESS1, \
                      RESOURCE, \
                      DUMMYVAL, \
-                     OSCOREMASTERSECRET, \
-                     OSCORESERVERID, \
-                     OSCORECLIENTID
+                     OSCOREDUMMYMASTERSECRETCONTEXT
 from coap     import coapDefines as d, \
                      coapException as e, \
                      coapOption as o, \
@@ -28,17 +28,13 @@ log.addHandler(utils.NullHandler())
 
 #============================ tests ===========================================
 
-DUMMYMASTERSECRET  = binascii.unhexlify('DEADBEEFDEADBEEFDEADBEEF')
-
 def test_BADREQUEST(logFixture, snoopyDispatcher, twoEndPoints, confirmableFixture):
     (coap1, coap2, securityEnabled) = twoEndPoints
 
     options = []
     if securityEnabled:
         # have coap2 do a get with the right IDs but wrong master secret
-        clientContext = oscore.SecurityContext(masterSecret=DUMMYMASTERSECRET,
-                                               senderID=OSCORESERVERID,
-                                               recipientID=OSCORECLIENTID)
+        clientContext = oscore.SecurityContext(OSCOREDUMMYMASTERSECRETCONTEXT)
 
         clientOptions = [o.ObjectSecurity(context=clientContext)]
 

--- a/tests/func/test_BADREQUEST.py
+++ b/tests/func/test_BADREQUEST.py
@@ -11,13 +11,13 @@ import binascii
 from conftest import IPADDRESS1, \
                      RESOURCE, \
                      DUMMYVAL, \
-                     OSCOAPMASTERSECRET, \
-                     OSCOAPSERVERID, \
-                     OSCOAPCLIENTID
+                     OSCOREMASTERSECRET, \
+                     OSCORESERVERID, \
+                     OSCORECLIENTID
 from coap     import coapDefines as d, \
                      coapException as e, \
                      coapOption as o, \
-                     coapObjectSecurity as oscoap
+                     coapObjectSecurity as oscore
 
 #============================ logging =========================================
 
@@ -36,9 +36,9 @@ def test_BADREQUEST(logFixture, snoopyDispatcher, twoEndPoints, confirmableFixtu
     options = []
     if securityEnabled:
         # have coap2 do a get with the right IDs but wrong master secret
-        clientContext = oscoap.SecurityContext(masterSecret=DUMMYMASTERSECRET,
-                                               senderID=OSCOAPSERVERID,
-                                               recipientID=OSCOAPCLIENTID)
+        clientContext = oscore.SecurityContext(masterSecret=DUMMYMASTERSECRET,
+                                               senderID=OSCORESERVERID,
+                                               recipientID=OSCORECLIENTID)
 
         clientOptions = [o.ObjectSecurity(context=clientContext)]
 

--- a/tests/func/test_INTERNALSERVERERROR.py
+++ b/tests/func/test_INTERNALSERVERERROR.py
@@ -15,7 +15,7 @@ from coap     import coapDefines as d, \
                      coapResource, \
                      coapException as e, \
                      coapOption as o, \
-                     coapObjectSecurity as oscoap
+                     coapObjectSecurity as oscore
 
 #============================ logging =========================================
 
@@ -54,13 +54,13 @@ def test_GET(logFixture,snoopyDispatcher,twoEndPoints):
     clientOptions = []
     buggyRes = buggyResource()
     if securityEnabled:
-        clientContext = oscoap.SecurityContext(masterSecret=DUMMYMASTERSECRET,
-                                         senderID=DUMMYSERVERID,
-                                         recipientID=DUMMYCLIENTID)
+        clientContext = oscore.SecurityContext(masterSecret=DUMMYMASTERSECRET,
+                                               senderID=DUMMYSERVERID,
+                                               recipientID=DUMMYCLIENTID)
 
         clientOptions = [o.ObjectSecurity(context=clientContext)]
 
-        serverContext = oscoap.SecurityContext(masterSecret=DUMMYMASTERSECRET,
+        serverContext = oscore.SecurityContext(masterSecret=DUMMYMASTERSECRET,
                                                senderID=DUMMYCLIENTID,
                                                recipientID=DUMMYSERVERID)
 

--- a/tests/func/test_INTERNALSERVERERROR.py
+++ b/tests/func/test_INTERNALSERVERERROR.py
@@ -10,7 +10,9 @@ import binascii
 
 from conftest import IPADDRESS1, \
                      RESOURCE, \
-                     DUMMYVAL
+                     DUMMYVAL, \
+                     OSCORECLIENTCONTEXT, \
+                     OSCORESERVERCONTEXT
 from coap     import coapDefines as d, \
                      coapResource, \
                      coapException as e, \
@@ -43,10 +45,6 @@ class buggyResource(coapResource.coapResource):
 
 #============================ tests ===========================================
 
-DUMMYMASTERSECRET  = binascii.unhexlify('DEADBEEFDEADBEEFDEADBEEF')
-DUMMYSERVERID      = binascii.unhexlify('CAFECAFECAFE')
-DUMMYCLIENTID      = binascii.unhexlify('FECAFECAFECA')
-
 def test_GET(logFixture,snoopyDispatcher,twoEndPoints):
     
     (coap1,coap2,securityEnabled) = twoEndPoints
@@ -54,18 +52,9 @@ def test_GET(logFixture,snoopyDispatcher,twoEndPoints):
     clientOptions = []
     buggyRes = buggyResource()
     if securityEnabled:
-        clientContext = oscore.SecurityContext(masterSecret=DUMMYMASTERSECRET,
-                                               senderID=DUMMYSERVERID,
-                                               recipientID=DUMMYCLIENTID)
+        clientContext = oscore.SecurityContext(OSCORECLIENTCONTEXT)
 
         clientOptions = [o.ObjectSecurity(context=clientContext)]
-
-        serverContext = oscore.SecurityContext(masterSecret=DUMMYMASTERSECRET,
-                                               senderID=DUMMYCLIENTID,
-                                               recipientID=DUMMYSERVERID)
-
-        buggyRes.addSecurityBinding((serverContext, d.METHOD_ALL))
-
 
     coap1.addResource(buggyRes)
     

--- a/tests/func/test_METHODNOTALLOWED.py
+++ b/tests/func/test_METHODNOTALLOWED.py
@@ -9,9 +9,7 @@ import pytest
 from conftest import IPADDRESS1, \
                      RESOURCE, \
                      DUMMYVAL, \
-                     OSCOREMASTERSECRET, \
-                     OSCORESERVERID, \
-                     OSCORECLIENTID
+                     OSCORECLIENTCONTEXT
 from coap     import coapDefines as d, \
                      coapException as e, \
                      coapOption as o, \
@@ -32,9 +30,7 @@ def test_METHODNOTALLOWED(logFixture,snoopyDispatcher,twoEndPoints,confirmableFi
 
     options = []
     if securityEnabled:
-        context = oscore.SecurityContext(masterSecret   = OSCOREMASTERSECRET,
-                                         senderID       = OSCORESERVERID,
-                                         recipientID    = OSCORECLIENTID)
+        context = oscore.SecurityContext(OSCORECLIENTCONTEXT)
 
         options = [o.ObjectSecurity(context=context)]
     

--- a/tests/func/test_METHODNOTALLOWED.py
+++ b/tests/func/test_METHODNOTALLOWED.py
@@ -9,13 +9,13 @@ import pytest
 from conftest import IPADDRESS1, \
                      RESOURCE, \
                      DUMMYVAL, \
-                     OSCOAPMASTERSECRET, \
-                     OSCOAPSERVERID, \
-                     OSCOAPCLIENTID
+                     OSCOREMASTERSECRET, \
+                     OSCORESERVERID, \
+                     OSCORECLIENTID
 from coap     import coapDefines as d, \
                      coapException as e, \
                      coapOption as o, \
-                     coapObjectSecurity as oscoap
+                     coapObjectSecurity as oscore
 
 #============================ logging =========================================
 
@@ -32,9 +32,9 @@ def test_METHODNOTALLOWED(logFixture,snoopyDispatcher,twoEndPoints,confirmableFi
 
     options = []
     if securityEnabled:
-        context = oscoap.SecurityContext(masterSecret   = OSCOAPMASTERSECRET,
-                                         senderID       = OSCOAPSERVERID,
-                                         recipientID    = OSCOAPCLIENTID)
+        context = oscore.SecurityContext(masterSecret   = OSCOREMASTERSECRET,
+                                         senderID       = OSCORESERVERID,
+                                         recipientID    = OSCORECLIENTID)
 
         options = [o.ObjectSecurity(context=context)]
     

--- a/tests/func/test_NOTFOUND.py
+++ b/tests/func/test_NOTFOUND.py
@@ -8,13 +8,13 @@ import pytest
 
 from conftest import IPADDRESS1, \
                      DUMMYVAL, \
-                     OSCOAPMASTERSECRET, \
-                     OSCOAPSERVERID, \
-                     OSCOAPCLIENTID
+                     OSCOREMASTERSECRET, \
+                     OSCORESERVERID, \
+                     OSCORECLIENTID
 from coap     import coapDefines as d, \
                      coapException as e, \
                      coapOption as o, \
-                     coapObjectSecurity as oscoap
+                     coapObjectSecurity as oscore
 
 #============================ logging =========================================
 
@@ -33,9 +33,9 @@ def test_NOTFOUND(logFixture,snoopyDispatcher,twoEndPoints,confirmableFixture):
 
     options = []
     if securityEnabled:
-        context = oscoap.SecurityContext(masterSecret=OSCOAPMASTERSECRET,
-                                         senderID=OSCOAPSERVERID,
-                                         recipientID=OSCOAPCLIENTID)
+        context = oscore.SecurityContext(masterSecret=OSCOREMASTERSECRET,
+                                         senderID=OSCORESERVERID,
+                                         recipientID=OSCORECLIENTID)
 
         options = [o.ObjectSecurity(context=context)]
     

--- a/tests/func/test_NOTFOUND.py
+++ b/tests/func/test_NOTFOUND.py
@@ -8,9 +8,7 @@ import pytest
 
 from conftest import IPADDRESS1, \
                      DUMMYVAL, \
-                     OSCOREMASTERSECRET, \
-                     OSCORESERVERID, \
-                     OSCORECLIENTID
+                     OSCORECLIENTCONTEXT
 from coap     import coapDefines as d, \
                      coapException as e, \
                      coapOption as o, \
@@ -33,9 +31,7 @@ def test_NOTFOUND(logFixture,snoopyDispatcher,twoEndPoints,confirmableFixture):
 
     options = []
     if securityEnabled:
-        context = oscore.SecurityContext(masterSecret=OSCOREMASTERSECRET,
-                                         senderID=OSCORESERVERID,
-                                         recipientID=OSCORECLIENTID)
+        context = oscore.SecurityContext(OSCORECLIENTCONTEXT)
 
         options = [o.ObjectSecurity(context=context)]
     

--- a/tests/func/test_UNAUTHORIZED.py
+++ b/tests/func/test_UNAUTHORIZED.py
@@ -7,13 +7,12 @@ import threading
 import pytest
 
 import binascii
+import os
 
 from conftest import IPADDRESS1, \
                      RESOURCE, \
                      DUMMYVAL, \
-                     OSCOREMASTERSECRET, \
-                     OSCORESERVERID, \
-                     OSCORECLIENTID
+                     OSCOREDUMMYSENDERIDCONTEXT
 from coap     import coapDefines as d, \
                      coapException as e, \
                      coapOption as o, \
@@ -27,6 +26,8 @@ log.addHandler(utils.NullHandler())
 #============================ logging =========================================
 
 #============================ tests ===========================================
+
+OSCOREDUMMYCONTEXT = os.path.join("oscore_context_dummy.json")
 
 def test_UNAUTHORIZED_1(logFixture,snoopyDispatcher,twoEndPoints,confirmableFixture):
     
@@ -44,19 +45,13 @@ def test_UNAUTHORIZED_1(logFixture,snoopyDispatcher,twoEndPoints,confirmableFixt
     else:
         pass
 
-DUMMYMASTERSECRET  = binascii.unhexlify('DEADBEEFDEADBEEFDEADBEEF')
-DUMMYSERVERID      = binascii.unhexlify('CAFECAFECAFE')
-DUMMYCLIENTID      = binascii.unhexlify('FECAFECAFECA')
-
 def test_UNAUTHORIZED_2(logFixture, snoopyDispatcher, twoEndPoints, confirmableFixture):
     (coap1, coap2, securityEnabled) = twoEndPoints
 
     options = []
     if securityEnabled:
         # have coap2 do a get with wrong context
-        clientContext = oscore.SecurityContext(masterSecret=DUMMYMASTERSECRET,
-                                               senderID=DUMMYSERVERID,
-                                               recipientID=DUMMYCLIENTID)
+        clientContext = oscore.SecurityContext(OSCOREDUMMYSENDERIDCONTEXT)
 
         clientOptions = [o.ObjectSecurity(context=clientContext)]
 

--- a/tests/func/test_UNAUTHORIZED.py
+++ b/tests/func/test_UNAUTHORIZED.py
@@ -11,13 +11,13 @@ import binascii
 from conftest import IPADDRESS1, \
                      RESOURCE, \
                      DUMMYVAL, \
-                     OSCOAPMASTERSECRET, \
-                     OSCOAPSERVERID, \
-                     OSCOAPCLIENTID
+                     OSCOREMASTERSECRET, \
+                     OSCORESERVERID, \
+                     OSCORECLIENTID
 from coap     import coapDefines as d, \
                      coapException as e, \
                      coapOption as o, \
-                     coapObjectSecurity as oscoap
+                     coapObjectSecurity as oscore
 
 #============================ logging =========================================
 
@@ -54,7 +54,7 @@ def test_UNAUTHORIZED_2(logFixture, snoopyDispatcher, twoEndPoints, confirmableF
     options = []
     if securityEnabled:
         # have coap2 do a get with wrong context
-        clientContext = oscoap.SecurityContext(masterSecret=DUMMYMASTERSECRET,
+        clientContext = oscore.SecurityContext(masterSecret=DUMMYMASTERSECRET,
                                                senderID=DUMMYSERVERID,
                                                recipientID=DUMMYCLIENTID)
 

--- a/tests/func/test_multiple_CON.py
+++ b/tests/func/test_multiple_CON.py
@@ -38,7 +38,7 @@ def test_GET(logFixture,snoopyDispatcher,twoEndPoints):
     for _ in range(20):
         reply = coap2.GET(
             uri         = 'coap://[{0}]:{1}/{2}/'.format(IPADDRESS1,d.DEFAULT_UDP_PORT,RESOURCE),
-            confirmable = False,
+            confirmable = True,
             options=options
         )
         assert reply==DUMMYVAL

--- a/tests/func/test_multiple_CON.py
+++ b/tests/func/test_multiple_CON.py
@@ -6,11 +6,8 @@ import threading
 
 from conftest import IPADDRESS1, \
                      RESOURCE, \
-                     DUMMYVAL, \
-                     OSCOREMASTERSECRET, \
-                     OSCORESERVERID, \
-                     OSCORECLIENTID
-
+                     DUMMYVAL,\
+                     OSCORECLIENTCONTEXT
 from coap     import coapDefines as d, \
                      coapOption as o, \
                      coapObjectSecurity as oscore
@@ -28,9 +25,7 @@ def test_GET(logFixture,snoopyDispatcher,twoEndPoints):
 
     options = []
     if securityEnabled:
-        context = oscore.SecurityContext(masterSecret   = OSCOREMASTERSECRET,
-                                         senderID       = OSCORESERVERID,
-                                         recipientID    = OSCORECLIENTID)
+        context = oscore.SecurityContext(OSCORECLIENTCONTEXT)
 
         options = [o.ObjectSecurity(context=context)]
     

--- a/tests/func/test_multiple_CON.py
+++ b/tests/func/test_multiple_CON.py
@@ -7,13 +7,13 @@ import threading
 from conftest import IPADDRESS1, \
                      RESOURCE, \
                      DUMMYVAL, \
-                     OSCOAPMASTERSECRET, \
-                     OSCOAPSERVERID, \
-                     OSCOAPCLIENTID
+                     OSCOREMASTERSECRET, \
+                     OSCORESERVERID, \
+                     OSCORECLIENTID
 
 from coap     import coapDefines as d, \
                      coapOption as o, \
-                     coapObjectSecurity as oscoap
+                     coapObjectSecurity as oscore
 
 #============================ logging ===============================
 
@@ -28,9 +28,9 @@ def test_GET(logFixture,snoopyDispatcher,twoEndPoints):
 
     options = []
     if securityEnabled:
-        context = oscoap.SecurityContext(masterSecret   = OSCOAPMASTERSECRET,
-                                         senderID       = OSCOAPSERVERID,
-                                         recipientID    = OSCOAPCLIENTID)
+        context = oscore.SecurityContext(masterSecret   = OSCOREMASTERSECRET,
+                                         senderID       = OSCORESERVERID,
+                                         recipientID    = OSCORECLIENTID)
 
         options = [o.ObjectSecurity(context=context)]
     

--- a/tests/func/test_multiple_NON.py
+++ b/tests/func/test_multiple_NON.py
@@ -7,12 +7,12 @@ import threading
 from conftest import IPADDRESS1, \
                      RESOURCE, \
                      DUMMYVAL, \
-                     OSCOAPMASTERSECRET, \
-                     OSCOAPSERVERID, \
-                     OSCOAPCLIENTID
+                     OSCOREMASTERSECRET, \
+                     OSCORESERVERID, \
+                     OSCORECLIENTID
 from coap     import coapDefines as d, \
                      coapOption as o, \
-                     coapObjectSecurity as oscoap
+                     coapObjectSecurity as oscore
 
 #============================ logging ===============================
 
@@ -27,9 +27,9 @@ def test_GET(logFixture,snoopyDispatcher,twoEndPoints):
 
     options = []
     if securityEnabled:
-        context = oscoap.SecurityContext(masterSecret   = OSCOAPMASTERSECRET,
-                                         senderID       = OSCOAPSERVERID,
-                                         recipientID    = OSCOAPCLIENTID)
+        context = oscore.SecurityContext(masterSecret   = OSCOREMASTERSECRET,
+                                         senderID       = OSCORESERVERID,
+                                         recipientID    = OSCORECLIENTID)
 
         options = [o.ObjectSecurity(context=context)]
     

--- a/tests/func/test_multiple_NON.py
+++ b/tests/func/test_multiple_NON.py
@@ -7,9 +7,7 @@ import threading
 from conftest import IPADDRESS1, \
                      RESOURCE, \
                      DUMMYVAL, \
-                     OSCOREMASTERSECRET, \
-                     OSCORESERVERID, \
-                     OSCORECLIENTID
+                     OSCORECLIENTCONTEXT
 from coap     import coapDefines as d, \
                      coapOption as o, \
                      coapObjectSecurity as oscore
@@ -27,9 +25,7 @@ def test_GET(logFixture,snoopyDispatcher,twoEndPoints):
 
     options = []
     if securityEnabled:
-        context = oscore.SecurityContext(masterSecret   = OSCOREMASTERSECRET,
-                                         senderID       = OSCORESERVERID,
-                                         recipientID    = OSCORECLIENTID)
+        context = oscore.SecurityContext(OSCORECLIENTCONTEXT)
 
         options = [o.ObjectSecurity(context=context)]
     

--- a/tests/func/test_single_CON.py
+++ b/tests/func/test_single_CON.py
@@ -7,12 +7,12 @@ import threading
 from conftest import IPADDRESS1, \
                      RESOURCE, \
                      DUMMYVAL, \
-                     OSCOAPMASTERSECRET, \
-                     OSCOAPSERVERID, \
-                     OSCOAPCLIENTID
+                     OSCOREMASTERSECRET, \
+                     OSCORESERVERID, \
+                     OSCORECLIENTID
 from coap     import coapDefines as d, \
                      coapOption as o, \
-                     coapObjectSecurity as oscoap
+                     coapObjectSecurity as oscore
 
 #============================ logging ===============================
 
@@ -26,9 +26,9 @@ def test_GET(logFixture,snoopyDispatcher,twoEndPoints):
 
     options = []
     if securityEnabled:
-        context = oscoap.SecurityContext(masterSecret   = OSCOAPMASTERSECRET,
-                                         senderID       = OSCOAPSERVERID,
-                                         recipientID    = OSCOAPCLIENTID)
+        context = oscore.SecurityContext(masterSecret   = OSCOREMASTERSECRET,
+                                         senderID       = OSCORESERVERID,
+                                         recipientID    = OSCORECLIENTID)
 
         options = [o.ObjectSecurity(context=context)]
 

--- a/tests/func/test_single_CON.py
+++ b/tests/func/test_single_CON.py
@@ -7,9 +7,7 @@ import threading
 from conftest import IPADDRESS1, \
                      RESOURCE, \
                      DUMMYVAL, \
-                     OSCOREMASTERSECRET, \
-                     OSCORESERVERID, \
-                     OSCORECLIENTID
+                     OSCORECLIENTCONTEXT
 from coap     import coapDefines as d, \
                      coapOption as o, \
                      coapObjectSecurity as oscore
@@ -26,9 +24,7 @@ def test_GET(logFixture,snoopyDispatcher,twoEndPoints):
 
     options = []
     if securityEnabled:
-        context = oscore.SecurityContext(masterSecret   = OSCOREMASTERSECRET,
-                                         senderID       = OSCORESERVERID,
-                                         recipientID    = OSCORECLIENTID)
+        context = oscore.SecurityContext(OSCORECLIENTCONTEXT)
 
         options = [o.ObjectSecurity(context=context)]
 

--- a/tests/func/test_single_NON.py
+++ b/tests/func/test_single_NON.py
@@ -7,12 +7,12 @@ import threading
 from conftest import IPADDRESS1, \
                      RESOURCE, \
                      DUMMYVAL, \
-                     OSCOAPMASTERSECRET, \
-                     OSCOAPSERVERID, \
-                     OSCOAPCLIENTID
+                     OSCOREMASTERSECRET, \
+                     OSCORESERVERID, \
+                     OSCORECLIENTID
 from coap     import coapDefines as d, \
                      coapOption as o, \
-                     coapObjectSecurity as oscoap
+                     coapObjectSecurity as oscore
 
 #============================ logging ===============================
 
@@ -27,9 +27,9 @@ def test_GET(logFixture,snoopyDispatcher,twoEndPoints):
 
     options = []
     if securityEnabled:
-        context = oscoap.SecurityContext(masterSecret   = OSCOAPMASTERSECRET,
-                                         senderID       = OSCOAPSERVERID,
-                                         recipientID    = OSCOAPCLIENTID)
+        context = oscore.SecurityContext(masterSecret   = OSCOREMASTERSECRET,
+                                         senderID       = OSCORESERVERID,
+                                         recipientID    = OSCORECLIENTID)
 
         options = [o.ObjectSecurity(context=context)]
     

--- a/tests/func/test_single_NON.py
+++ b/tests/func/test_single_NON.py
@@ -7,9 +7,7 @@ import threading
 from conftest import IPADDRESS1, \
                      RESOURCE, \
                      DUMMYVAL, \
-                     OSCOREMASTERSECRET, \
-                     OSCORESERVERID, \
-                     OSCORECLIENTID
+                     OSCORECLIENTCONTEXT
 from coap     import coapDefines as d, \
                      coapOption as o, \
                      coapObjectSecurity as oscore
@@ -27,9 +25,7 @@ def test_GET(logFixture,snoopyDispatcher,twoEndPoints):
 
     options = []
     if securityEnabled:
-        context = oscore.SecurityContext(masterSecret   = OSCOREMASTERSECRET,
-                                         senderID       = OSCORESERVERID,
-                                         recipientID    = OSCORECLIENTID)
+        context = oscore.SecurityContext(OSCORECLIENTCONTEXT)
 
         options = [o.ObjectSecurity(context=context)]
     

--- a/tests/func/test_timeout_CON.py
+++ b/tests/func/test_timeout_CON.py
@@ -9,9 +9,7 @@ import pytest
 from conftest import IPADDRESS1, \
                      RESOURCE, \
                      DUMMYVAL, \
-                     OSCOREMASTERSECRET, \
-                     OSCORESERVERID, \
-                     OSCORECLIENTID
+                     OSCORECLIENTCONTEXT
 from coap     import coapDefines as d, \
                      coapException as e, \
                      coapOption as o, \
@@ -38,9 +36,7 @@ def test_GET(logFixture,snoopyDispatcher,twoEndPoints):
 
     options = []
     if securityEnabled:
-        context = oscore.SecurityContext(masterSecret=OSCOREMASTERSECRET,
-                                         senderID=OSCORESERVERID,
-                                         recipientID=OSCORECLIENTID)
+        context = oscore.SecurityContext(OSCORECLIENTCONTEXT)
 
         options = [o.ObjectSecurity(context=context)]
     

--- a/tests/func/test_timeout_CON.py
+++ b/tests/func/test_timeout_CON.py
@@ -9,13 +9,13 @@ import pytest
 from conftest import IPADDRESS1, \
                      RESOURCE, \
                      DUMMYVAL, \
-                     OSCOAPMASTERSECRET, \
-                     OSCOAPSERVERID, \
-                     OSCOAPCLIENTID
+                     OSCOREMASTERSECRET, \
+                     OSCORESERVERID, \
+                     OSCORECLIENTID
 from coap     import coapDefines as d, \
                      coapException as e, \
                      coapOption as o, \
-                     coapObjectSecurity as oscoap
+                     coapObjectSecurity as oscore
 
 #============================ logging =========================================
 
@@ -38,9 +38,9 @@ def test_GET(logFixture,snoopyDispatcher,twoEndPoints):
 
     options = []
     if securityEnabled:
-        context = oscoap.SecurityContext(masterSecret=OSCOAPMASTERSECRET,
-                                         senderID=OSCOAPSERVERID,
-                                         recipientID=OSCOAPCLIENTID)
+        context = oscore.SecurityContext(masterSecret=OSCOREMASTERSECRET,
+                                         senderID=OSCORESERVERID,
+                                         recipientID=OSCORECLIENTID)
 
         options = [o.ObjectSecurity(context=context)]
     

--- a/tests/func/test_timeout_NON.py
+++ b/tests/func/test_timeout_NON.py
@@ -9,9 +9,7 @@ import pytest
 from conftest import IPADDRESS1, \
                      RESOURCE, \
                      DUMMYVAL, \
-                     OSCOREMASTERSECRET, \
-                     OSCORESERVERID, \
-                     OSCORECLIENTID
+                     OSCORECLIENTCONTEXT
 from coap     import coapDefines as d, \
                      coapException as e, \
                      coapOption as o, \
@@ -38,9 +36,7 @@ def test_GET(logFixture,snoopyDispatcher,twoEndPoints):
 
     options = []
     if securityEnabled:
-        context = oscore.SecurityContext(masterSecret=OSCOREMASTERSECRET,
-                                         senderID=OSCORESERVERID,
-                                         recipientID=OSCORECLIENTID)
+        context = oscore.SecurityContext(OSCORECLIENTCONTEXT)
 
         options = [o.ObjectSecurity(context=context)]
     

--- a/tests/func/test_timeout_NON.py
+++ b/tests/func/test_timeout_NON.py
@@ -9,13 +9,13 @@ import pytest
 from conftest import IPADDRESS1, \
                      RESOURCE, \
                      DUMMYVAL, \
-                     OSCOAPMASTERSECRET, \
-                     OSCOAPSERVERID, \
-                     OSCOAPCLIENTID
+                     OSCOREMASTERSECRET, \
+                     OSCORESERVERID, \
+                     OSCORECLIENTID
 from coap     import coapDefines as d, \
                      coapException as e, \
                      coapOption as o, \
-                     coapObjectSecurity as oscoap
+                     coapObjectSecurity as oscore
 
 #============================ logging =========================================
 
@@ -38,9 +38,9 @@ def test_GET(logFixture,snoopyDispatcher,twoEndPoints):
 
     options = []
     if securityEnabled:
-        context = oscoap.SecurityContext(masterSecret=OSCOAPMASTERSECRET,
-                                         senderID=OSCOAPSERVERID,
-                                         recipientID=OSCOAPCLIENTID)
+        context = oscore.SecurityContext(masterSecret=OSCOREMASTERSECRET,
+                                         senderID=OSCORESERVERID,
+                                         recipientID=OSCORECLIENTID)
 
         options = [o.ObjectSecurity(context=context)]
     

--- a/tests/oscore_test_context_client.json
+++ b/tests/oscore_test_context_client.json
@@ -1,0 +1,13 @@
+{
+    "aeadAlgorithm": "AES_CCM_16_64_128", 
+    "hashFunction": "sha256", 
+    "idContext": "37cbf3210017a2d3", 
+    "masterSalt": "9e7ca92223786340", 
+    "masterSecret": "0102030405060708090a0b0c0d0e0f10", 
+    "recipientID": "01", 
+    "replayWindow": [
+        0
+    ], 
+    "senderID": "", 
+    "sequenceNumber": 0
+}

--- a/tests/oscore_test_context_dummymastersecret.json
+++ b/tests/oscore_test_context_dummymastersecret.json
@@ -1,0 +1,13 @@
+{
+    "aeadAlgorithm": "AES_CCM_16_64_128", 
+    "hashFunction": "sha256", 
+    "idContext": "37cbf3210017a2d3", 
+    "masterSalt": "9e7ca92223786340", 
+    "masterSecret": "DEADBEEFDEADBEEFDEADBEEF", 
+    "recipientID": "01", 
+    "replayWindow": [
+        0
+    ], 
+    "senderID": "", 
+    "sequenceNumber": 0
+}

--- a/tests/oscore_test_context_dummysenderid.json
+++ b/tests/oscore_test_context_dummysenderid.json
@@ -1,0 +1,13 @@
+{
+    "aeadAlgorithm": "AES_CCM_16_64_128", 
+    "hashFunction": "sha256", 
+    "idContext": "37cbf3210017a2d3", 
+    "masterSalt": "9e7ca92223786340", 
+    "masterSecret": "DEADBEEFDEADBEEFDEADBEEF", 
+    "recipientID": "01", 
+    "replayWindow": [
+        0
+    ], 
+    "senderID": "DEADBEEF", 
+    "sequenceNumber": 0
+}

--- a/tests/oscore_test_context_server.json
+++ b/tests/oscore_test_context_server.json
@@ -1,0 +1,13 @@
+{
+    "aeadAlgorithm": "AES_CCM_16_64_128", 
+    "hashFunction": "sha256", 
+    "idContext": "37cbf3210017a2d3", 
+    "masterSalt": "9e7ca92223786340", 
+    "masterSecret": "0102030405060708090a0b0c0d0e0f10", 
+    "recipientID": "", 
+    "replayWindow": [
+        0
+    ], 
+    "senderID": "01", 
+    "sequenceNumber": 0
+}


### PR DESCRIPTION
This PR:
- Updates the OSCORE implementation to RFC8613. 
- Introduces a change in the implementation and corresponding API to persist the security context parameters on the disk. A JSON file containing the security parameters is required to initialize the OSCORE security context. This file is updated by the implementation with mutable context parameters such as sender sequence number and replay window state.
- Fixes a bug that was causing some test runs to stall.